### PR TITLE
Add update capacity for book shelves

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -17,6 +17,25 @@ class BooksApp extends React.Component {
   componentDidMount() {
     BooksAPI.getAll().then(books => this.setState({ books }));
   }
+  updateBookShelfHandler = (book, shelf) => {
+    BooksAPI.update(book, shelf).then(data => {
+      const updatedShelf = Object.keys(data).find(
+        key => data[key].filter(itemId => itemId === book.id)[0]
+      );
+      if (updatedShelf === shelf) {
+        this.setState(prevState => ({
+          books: [
+            ...prevState.books.filter(item => item.id !== book.id),
+            { ...book, shelf }
+          ]
+        }));
+      } else {
+        this.setState(prevState => ({
+          books: [...prevState.books.filter(item => item.id !== book.id)]
+        }));
+      }
+    });
+  };
   render() {
     return (
       <div className="app">
@@ -24,7 +43,11 @@ class BooksApp extends React.Component {
           exact
           path="/"
           render={() => (
-            <List books={this.state.books} shelves={this.shelves} />
+            <List
+              books={this.state.books}
+              shelves={this.shelves}
+              onBookUpdate={this.updateBookShelfHandler}
+            />
           )}
         />
         <Route

--- a/src/components/Book.js
+++ b/src/components/Book.js
@@ -4,12 +4,15 @@ import BookCover from './BookCover';
 import BookOptions from './BookOptions';
 import BookAuthors from './BookAuthors';
 
-const Book = ({ book }) => (
+const Book = ({ book, onUpdate }) => (
   <li>
     <div className="book">
       <div className="book-top">
         <BookCover imageLinks={book.imageLinks} />
-        <BookOptions shelf={book.shelf} />
+        <BookOptions
+          shelf={book.shelf}
+          onUpdate={shelf => onUpdate(book, shelf)}
+        />
       </div>
       <div className="book-title">{book.title}</div>
       <BookAuthors authors={book.authors} />
@@ -23,7 +26,8 @@ Book.propTypes = {
     shelf: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
     authors: PropTypes.array.isRequired
-  }).isRequired
+  }).isRequired,
+  onUpdate: PropTypes.func.isRequired
 };
 
 export default Book;

--- a/src/components/Book.test.js
+++ b/src/components/Book.test.js
@@ -7,7 +7,8 @@ describe('Book', () => {
   const props = {
     book: {
       ...BookMockData
-    }
+    },
+    onUpdate: jest.fn()
   };
   it('should render properly', () => {
     const wrapper = shallow(<Book {...props} />);

--- a/src/components/BookCover.test.js
+++ b/src/components/BookCover.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import BookCover from './BookCover';
+
+describe('Book Cover', () => {
+  it('should render cover if received', () => {
+    const imageLinks = { thumbnail: 'thumbnail' };
+    const wrapper = shallow(<BookCover imageLinks={imageLinks} />);
+
+    const cover = wrapper.find('div');
+
+    expect(cover.props().style.backgroundImage).toBe('url(thumbnail)');
+  });
+
+  it('should not render background image if none is received', () => {
+    const imageLinks = { thumbnail: null };
+    const wrapper = shallow(<BookCover imageLinks={imageLinks} />);
+
+    const cover = wrapper.find('div');
+
+    expect(cover.props().style).not.toContain('backgroundImage');
+  });
+
+  it('should set height and weight overwriting defaultProps', () => {
+    const props = { imageLinks: { thumbnail: null }, width: 60, height: 60 };
+    const wrapper = shallow(<BookCover {...props} />);
+
+    const cover = wrapper.find('div');
+
+    expect(cover.props().style).toMatchObject({ width: 60, height: 60 });
+  });
+});

--- a/src/components/BookOptions.js
+++ b/src/components/BookOptions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const BookOptions = ({ shelf, onChange }) => {
+const BookOptions = ({ shelf, onUpdate }) => {
   const options = [
     { key: 'currentlyReading', name: 'Currently Reading' },
     { key: 'wantToRead', name: 'Want to Read' },
@@ -10,7 +10,7 @@ const BookOptions = ({ shelf, onChange }) => {
   ];
   return (
     <div className="book-shelf-changer">
-      <select value={shelf} onChange={onChange}>
+      <select value={shelf} onChange={event => onUpdate(event.target.value)}>
         <option value="move" disabled>
           Move to...
         </option>
@@ -26,7 +26,7 @@ const BookOptions = ({ shelf, onChange }) => {
 
 BookOptions.propTypes = {
   shelf: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired
+  onUpdate: PropTypes.func.isRequired
 };
 
 export default BookOptions;

--- a/src/components/BookOptions.test.js
+++ b/src/components/BookOptions.test.js
@@ -5,7 +5,7 @@ import BookOptions from './BookOptions';
 describe('Book Options', () => {
   const props = {
     shelf: 'wantToRead',
-    onChange: jest.fn()
+    onUpdate: jest.fn()
   };
 
   it('should show the selection value received', () => {
@@ -22,5 +22,13 @@ describe('Book Options', () => {
     const select = wrapper.find('select');
 
     expect(select.props().value).toBe('');
+  });
+
+  it('should call onUpdate on change', () => {
+    const wrapper = shallow(<BookOptions {...props} />);
+
+    wrapper.find('select').simulate('change', { target: { value: 'read' } });
+
+    expect(props.onUpdate).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/BookShelf.js
+++ b/src/components/BookShelf.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Book from './Book';
 
-const BookShelf = ({ name, books, shelf }) => (
+const BookShelf = ({ name, books, shelf, onBookUpdate }) => (
   <div className="bookshelf">
     <h2 className="bookshelf-title">{name}</h2>
     <div className="bookshelf-books">
@@ -10,7 +10,7 @@ const BookShelf = ({ name, books, shelf }) => (
         {books
           .filter(book => book.shelf === shelf)
           .map(book => (
-            <Book key={book.id} book={book} />
+            <Book key={book.id} book={book} onUpdate={onBookUpdate} />
           ))}
       </ol>
     </div>
@@ -20,7 +20,8 @@ const BookShelf = ({ name, books, shelf }) => (
 BookShelf.propTypes = {
   name: PropTypes.string.isRequired,
   books: PropTypes.array.isRequired,
-  shelf: PropTypes.string.isRequired
+  shelf: PropTypes.string.isRequired,
+  onBookUpdate: PropTypes.func.isRequired
 };
 
 export default BookShelf;

--- a/src/components/BookShelf.test.js
+++ b/src/components/BookShelf.test.js
@@ -31,7 +31,8 @@ describe('Book Shelf', () => {
         tittle: 'book4',
         shelf: 'sh3'
       }
-    ]
+    ],
+    onBookUpdate: jest.fn()
   };
 
   it('should filter books by shelf', () => {

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import BookShelf from './BookShelf';
 
-const List = ({ books, shelves }) => (
+const List = ({ books, shelves, onBookUpdate }) => (
   <div className="list-books">
     <div className="list-books-title">
       <h1>MyReads</h1>
@@ -16,6 +16,7 @@ const List = ({ books, shelves }) => (
             shelf={shelf.type}
             name={shelf.name}
             books={books}
+            onBookUpdate={onBookUpdate}
           />
         ))}
       </div>
@@ -28,7 +29,8 @@ const List = ({ books, shelves }) => (
 
 List.propTypes = {
   books: PropTypes.array.isRequired,
-  shelves: PropTypes.array.isRequired
+  shelves: PropTypes.array.isRequired,
+  onBookUpdate: PropTypes.func.isRequired
 };
 
 export default List;

--- a/src/components/List.test.js
+++ b/src/components/List.test.js
@@ -6,7 +6,8 @@ import BookShelf from './BookShelf';
 describe('List', () => {
   const props = {
     books: [],
-    shelves: [{ name: 'Sh 1', type: 'sh1' }, { name: 'Sh 2', type: 'sh2' }]
+    shelves: [{ name: 'Sh 1', type: 'sh1' }, { name: 'Sh 2', type: 'sh2' }],
+    onBookUpdate: jest.fn()
   };
 
   it('should render as multilple shelves as received', () => {

--- a/src/components/__snapshots__/Book.test.js.snap
+++ b/src/components/__snapshots__/Book.test.js.snap
@@ -54,6 +54,7 @@ ShallowWrapper {
         "title": "The Linux Command Line",
       }
     }
+    onUpdate={[MockFunction]}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -85,6 +86,7 @@ ShallowWrapper {
             width={128}
           />
           <BookOptions
+            onUpdate={[Function]}
             shelf="currentlyReading"
           />
         </div>
@@ -123,6 +125,7 @@ ShallowWrapper {
               width={128}
             />
             <BookOptions
+              onUpdate={[Function]}
               shelf="currentlyReading"
             />
           </div>,
@@ -160,6 +163,7 @@ ShallowWrapper {
                 width={128}
               />,
               <BookOptions
+                onUpdate={[Function]}
                 shelf="currentlyReading"
               />,
             ],
@@ -188,6 +192,7 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "function",
               "props": Object {
+                "onUpdate": [Function],
                 "shelf": "currentlyReading",
               },
               "ref": null,
@@ -250,6 +255,7 @@ ShallowWrapper {
               width={128}
             />
             <BookOptions
+              onUpdate={[Function]}
               shelf="currentlyReading"
             />
           </div>
@@ -288,6 +294,7 @@ ShallowWrapper {
                 width={128}
               />
               <BookOptions
+                onUpdate={[Function]}
                 shelf="currentlyReading"
               />
             </div>,
@@ -325,6 +332,7 @@ ShallowWrapper {
                   width={128}
                 />,
                 <BookOptions
+                  onUpdate={[Function]}
                   shelf="currentlyReading"
                 />,
               ],
@@ -353,6 +361,7 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "function",
                 "props": Object {
+                  "onUpdate": [Function],
                   "shelf": "currentlyReading",
                 },
                 "ref": null,


### PR DESCRIPTION
## Why?

As a user
In order to improve the experience and organize my books
I want to move books from shelf to shelf

As a user
In order to improve the experience and select my personalized content
I want to remove a book from my shelves

As a developer
In order to improve the quality of the code and the reliability of the application
I want to run improved unit tests throughout the development, testing important features

## Notes

- In this PR there is one thing that I not quite happy about it. I am processing the Update response of the API in a way that is too complex. This would not be necessary if the API had a proper response.
- The response is focused on the Filter, but this implies in having dynamic data as state keys, which I do not agree and I strongly prefer to avoid.
- Another point is that it is not necessarily good to have the data filtered if you are not using the filter data but instead, you only have the ids filtered, still needing to get the rest of the data via a filter. I would rather go with the presented solution where there is a separation of concerns and the BookShelf component, is always responsible for filtering the books that come in. I do not love this implementation, but I think it is more reliable, since we can always have new shelves and I do not believe that changing the state is any good for the app, every time a new shelf appears.