### PR TITLE
Book options should reflect shelf

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,20 +3,30 @@ import { Route } from 'react-router-dom';
 import * as BooksAPI from '../api/BooksAPI';
 import Search from './Search';
 import List from './List';
+import { convertResponseFilters } from '../helpers';
 import './App.css';
 
 class BooksApp extends React.Component {
   state = {
-    books: []
+    books: [],
+    filteredByShelf: {}
   };
   shelves = [
     { name: 'Currently Reading', type: 'currentlyReading' },
     { name: 'Want to Read', type: 'wantToRead' },
     { name: 'Read', type: 'read' }
   ];
+
   componentDidMount() {
-    BooksAPI.getAll().then(books => this.setState({ books }));
+    BooksAPI.getAll().then(books => {
+      const filteredByShelf = books.reduce((f, book) => {
+        f[book.id] = book.shelf;
+        return f;
+      }, {});
+      this.setState({ books, filteredByShelf });
+    });
   }
+
   updateBookShelfHandler = (book, shelf) => {
     BooksAPI.update(book, shelf).then(data => {
       const updatedShelf = Object.keys(data).find(
@@ -27,15 +37,18 @@ class BooksApp extends React.Component {
           books: [
             ...prevState.books.filter(item => item.id !== book.id),
             { ...book, shelf }
-          ]
+          ],
+          filteredByShelf: convertResponseFilters(data)
         }));
       } else {
         this.setState(prevState => ({
-          books: [...prevState.books.filter(item => item.id !== book.id)]
+          books: [...prevState.books.filter(item => item.id !== book.id)],
+          filteredByShelf: convertResponseFilters(data)
         }));
       }
     });
   };
+
   render() {
     return (
       <div className="app">
@@ -52,7 +65,12 @@ class BooksApp extends React.Component {
         />
         <Route
           path="/search"
-          render={() => <Search onBookUpdate={this.updateBookShelfHandler} />}
+          render={() => (
+            <Search
+              onBookUpdate={this.updateBookShelfHandler}
+              filteredByShelf={this.state.filteredByShelf}
+            />
+          )}
         />
       </div>
     );

--- a/src/components/BookOptions.js
+++ b/src/components/BookOptions.js
@@ -8,9 +8,13 @@ const BookOptions = ({ shelf, onUpdate }) => {
     { key: 'read', name: 'Read' },
     { key: 'none', name: 'None' }
   ];
+  const selectedShelf = shelf || 'none';
   return (
     <div className="book-shelf-changer">
-      <select value={shelf} onChange={event => onUpdate(event.target.value)}>
+      <select
+        value={selectedShelf}
+        onChange={event => onUpdate(event.target.value)}
+      >
         <option value="move" disabled>
           Move to...
         </option>
@@ -27,10 +31,6 @@ const BookOptions = ({ shelf, onUpdate }) => {
 BookOptions.propTypes = {
   shelf: PropTypes.string,
   onUpdate: PropTypes.func.isRequired
-};
-
-BookOptions.defaulProps = {
-  shelf: null
 };
 
 export default BookOptions;

--- a/src/components/BookOptions.test.js
+++ b/src/components/BookOptions.test.js
@@ -16,12 +16,12 @@ describe('Book Options', () => {
     expect(select.props().value).toBe('wantToRead');
   });
 
-  it('should show no selection if no value is received', () => {
+  it('should show None if no value is received', () => {
     const wrapper = shallow(<BookOptions {...props} shelf="" />);
 
     const select = wrapper.find('select');
 
-    expect(select.props().value).toBe('');
+    expect(select.props().value).toBe('none');
   });
 
   it('should call onUpdate on change', () => {

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { throttle, debounce } from 'throttle-debounce';
 import { Link } from 'react-router-dom';
 import { search } from '../api/BooksAPI';
-import Book from './Book';
+import SearchedResults from './SearchResults';
 
 class Search extends React.Component {
   state = {
@@ -45,25 +45,23 @@ class Search extends React.Component {
             />
           </div>
         </div>
-        <div className="search-books-results">
-          {this.state.error && <p>{this.state.error}</p>}
-          <ol className="books-grid">
-            {this.state.searchedBooks.map(book => (
-              <Book
-                key={book.id}
-                book={book}
-                onUpdate={this.props.onBookUpdate}
-              />
-            ))}
-          </ol>
-        </div>
+        <SearchedResults
+          onBookUpdate={this.props.onBookUpdate}
+          searched={this.state.searchedBooks}
+          filtered={this.props.filteredByShelf}
+        />
       </div>
     );
   }
 }
 
 Search.propTypes = {
-  onBookUpdate: PropTypes.func.isRequired
+  onBookUpdate: PropTypes.func.isRequired,
+  filteredByShelf: PropTypes.object.isRequired
+};
+
+Search.defaultProps = {
+  filteredByShelf: {}
 };
 
 export default Search;

--- a/src/components/Search.test.js
+++ b/src/components/Search.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { throttle, debounce } from 'throttle-debounce';
 import Search from './Search';
-import Book from './Book';
+import SearchResults from './SearchResults';
 import searchData from './__mocks__/searchData';
 
 jest.mock('throttle-debounce', () => ({
@@ -40,9 +40,9 @@ describe('Search', () => {
       .instance()
       .setState({ searchedBooks: searchData.books, query: 'sci' });
 
-    const books = wrapper.find(Book);
+    const results = wrapper.find(SearchResults);
 
-    expect(books.length).toBe(2);
+    expect(results.props().searched.length).toBe(2);
   });
 
   it('should should show no books if no books were found', () => {
@@ -50,9 +50,9 @@ describe('Search', () => {
     const input = wrapper.find('input');
 
     input.simulate('change', { target: { value: 'momentum' } });
-    const books = wrapper.find(Book);
+    const results = wrapper.find(SearchResults);
 
-    expect(books.length).toBe(0);
+    expect(results.props().searched.length).toBe(0);
   });
 
   it('should should show no books if search field is empty', () => {
@@ -60,8 +60,8 @@ describe('Search', () => {
     const input = wrapper.find('input');
 
     input.simulate('change', { target: { value: '' } });
-    const books = wrapper.find(Book);
+    const results = wrapper.find(SearchResults);
 
-    expect(books.length).toBe(0);
+    expect(results.props().searched.length).toBe(0);
   });
 });

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Book from './Book';
+
+const SearchResults = ({ filtered, searched, onBookUpdate }) => (
+  <div className="search-books-results">
+    <ol className="books-grid">
+      {searched.map(book => {
+        const bookEnhanced = filtered[book.id]
+          ? { ...book, shelf: filtered[book.id] }
+          : book;
+        return (
+          <Book key={book.id} book={bookEnhanced} onUpdate={onBookUpdate} />
+        );
+      })}
+    </ol>
+  </div>
+);
+
+SearchResults.propTypes = {
+  searched: PropTypes.array,
+  filtered: PropTypes.object.isRequired,
+  onBookUpdate: PropTypes.func.isRequired
+};
+
+SearchResults.defaultProps = {
+  searched: []
+};
+
+export default SearchResults;

--- a/src/components/SearchResults.test.js
+++ b/src/components/SearchResults.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SearchResults from './SearchResults';
+import Book from './Book';
+import searchedBooks from './__mocks__/searchData';
+
+describe('Search Results', () => {
+  const props = {
+    searched: searchedBooks.books,
+    filtered: { F3JU3SJ5fDIC: 'read' },
+    onBookUpdate: jest.fn()
+  };
+
+  it('should append shelf property to the list if matches the book id', () => {
+    const wrapper = shallow(<SearchResults {...props} />);
+
+    const book = wrapper.find(Book).first();
+    const bookSearched = book.props().book;
+
+    expect(bookSearched.shelf).toBe('read');
+  });
+
+  it('should not append shelf property to the list if does not match the book id', () => {
+    const wrapper = shallow(<SearchResults {...props} filtered={{}} />);
+
+    const book = wrapper.find(Book).first();
+    const bookSearched = book.props().book;
+
+    expect(bookSearched.shelf).not.toBeDefined();
+  });
+
+  it('should render the ammount of books found on the search', () => {
+    const wrapper = shallow(<SearchResults {...props} />);
+
+    const book = wrapper.find(Book);
+
+    expect(book.length).toBe(2);
+  });
+});

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,0 +1,8 @@
+export const convertResponseFilters = data =>
+  Object.keys(data).reduce((f, shelf) => {
+    data[shelf].map(item => {
+      f[item] = shelf;
+      return f[item];
+    });
+    return f;
+  }, {});

--- a/src/helpers/index.test.js
+++ b/src/helpers/index.test.js
@@ -1,0 +1,21 @@
+import { convertResponseFilters } from './';
+
+describe('Helpers', () => {
+  it('`convertResponseFilters` should transpose data from response', () => {
+    const mockData = {
+      currentlyReading: ['sJf1vQAACAAJ', 'xlp6NE2NWecC', 'HfbBDAAAQBAJ'],
+      wantToRead: ['evuwdDLfAyYC'],
+      read: ['jAUODAAAQBAJ']
+    };
+
+    const transposed = convertResponseFilters(mockData);
+
+    expect(transposed).toMatchObject({
+      sJf1vQAACAAJ: 'currentlyReading',
+      xlp6NE2NWecC: 'currentlyReading',
+      HfbBDAAAQBAJ: 'currentlyReading',
+      evuwdDLfAyYC: 'wantToRead',
+      jAUODAAAQBAJ: 'read'
+    });
+  });
+});


### PR DESCRIPTION
## Why?

As a user
In order to have the experience of managing my books no matter main screen I am
I want to add books from my search results to my shelves

As a developer
In order to have a consistent state management
I want to have helpers to manage this transposing of data since the API is not so nice in terms of response.

